### PR TITLE
Update README with accurate information

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ npm install markdown-it
 Install the plugin
 
 ```bash
-npm install @iktakahiro/markdown-it-katex
+npm install @vscode/markdown-it-katex
 ```
 
 Use it in your javascript
 
 ```javascript
 var md = require('markdown-it')(),
-    mk = require('@iktakahiro/markdown-it-katex');
+    mk = require('@vscode/markdown-it-katex');
 
 md.use(mk);
 
@@ -37,7 +37,7 @@ var result = md.render('# Math Rulez! \n  $\\sqrt{3x-1}+(1+x)^2$');
 Include the KaTeX stylesheet in your html:
 
 ```html
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/katex.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.4/dist/katex.min.css">
 ```
 
 If you're using the default markdown-it parser, I also recommend the [github stylesheet](https://github.com/sindresorhus/github-markdown-css):


### PR DESCRIPTION
This package is called `@vscode/markdown-it-katex`, not the original. Users of this package can be confused about the README. This PR fixes the confusion.