### PR TITLE
Add fenced math block option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -497,7 +497,7 @@ export default function (md: import('markdown-it'), options?: MarkdownKatexOptio
 
 
     md.inline.ruler.after('escape', 'math_inline', inlineMath);
-    md.inline.ruler.after('escape', 'math_inline_block'git , inlineMathBlock);
+    md.inline.ruler.after('escape', 'math_inline_block', inlineMathBlock);
     if (enableBareBlocks) {
         md.inline.ruler.before('text', 'math_inline_bare_block', inlineBareBlock);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -462,6 +462,7 @@ export default function (md: import('markdown-it'), options?: MarkdownKatexOptio
     const enableBareBlocks = options?.enableBareBlocks;
     const enableMathBlockInHtml = options?.enableMathBlockInHtml;
     const enableMathInlineInHtml = options?.enableMathInlineInHtml;
+    const enableFencedBlocks = options?.enableFencedBlocks;
 
     const katexInline = (latex: string) => {
         const displayMode = /\\begin\{(align|equation|gather|cd|alignat)\}/ig.test(latex);
@@ -494,8 +495,9 @@ export default function (md: import('markdown-it'), options?: MarkdownKatexOptio
         return katexBlockRenderer(tokens[idx].content) + '\n';
     }
 
+
     md.inline.ruler.after('escape', 'math_inline', inlineMath);
-    md.inline.ruler.after('escape', 'math_inline_block', inlineMathBlock);
+    md.inline.ruler.after('escape', 'math_inline_block'git , inlineMathBlock);
     if (enableBareBlocks) {
         md.inline.ruler.before('text', 'math_inline_bare_block', inlineBareBlock);
     }
@@ -508,6 +510,16 @@ export default function (md: import('markdown-it'), options?: MarkdownKatexOptio
     }, {
         alt: ['paragraph', 'reference', 'blockquote', 'list']
     });
+
+    const originalFenceRenderer = md.renderer.rules.fence;
+    md.renderer.rules.fence = function (tokens: Token[], idx: number, options, env, self) {
+        const token = tokens[idx];
+        if (token.info.trim() === 'math' && enableFencedBlocks) {
+            return blockRenderer([token], 0);
+        } else {
+            return originalFenceRenderer?.call(this, tokens, idx, options, env, self) || '';
+        }
+    };
 
     // Regex to capture any html prior to math block, the math block (single or multi line), and any html after the math block
     const math_block_within_html_regex = /(?<html_before_math>[\s\S]*?)\$\$(?<math>[\s\S]+?)\$\$(?<html_after_math>(?:(?!\$\$[\s\S]+?\$\$)[\s\S])*)/gm;

--- a/test/all.js
+++ b/test/all.js
@@ -50,3 +50,5 @@ runTest(path.join(__dirname, 'fixtures', 'default.txt'), mdIt({ html: true }).us
 runTest(path.join(__dirname, 'fixtures', 'bare.txt'), mdIt().use(mdk, { enableBareBlocks: true }));
 
 runTest(path.join(__dirname, 'fixtures', 'math-in-html.txt'), mdIt({ html: true }).use(mdk, { enableMathBlockInHtml: true, enableMathInlineInHtml: true }));
+
+runTest(path.join(__dirname, 'fixtures', 'fence.txt'), mdIt({ html: true }).use(mdk, { enableFencedBlocks: true }));

--- a/test/fixtures/fence.txt
+++ b/test/fixtures/fence.txt
@@ -1,0 +1,85 @@
+Simple fence block with backticks
+.
+start
+
+```math
+2
+```
+
+end
+.
+<p>start</p>
+<p class="katex-block"><span class="katex-display"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mn>2</mn></mrow><annotation encoding="application/x-tex">2
+</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.6444em;"></span><span class="mord">2</span></span></span></span></span></p>
+<p>end</p>
+.
+
+Simple fence block with tildes
+.
+start
+
+~~~math
+2
+~~~
+
+end
+.
+<p>start</p>
+<p class="katex-block"><span class="katex-display"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mn>2</mn></mrow><annotation encoding="application/x-tex">2
+</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.6444em;"></span><span class="mord">2</span></span></span></span></span></p>
+<p>end</p>
+.
+
+Fence block without newlines
+.
+start
+```math
+2
+```
+end
+.
+<p>start</p>
+<p class="katex-block"><span class="katex-display"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mn>2</mn></mrow><annotation encoding="application/x-tex">2
+</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.6444em;"></span><span class="mord">2</span></span></span></span></span></p>
+<p>end</p>
+.
+
+Fence block on multiple lines
+.
+```math
+f(x) = ax^2 +
+bx + c
+```
+.
+<p class="katex-block"><span class="katex-display"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mi>f</mi><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo><mo>=</mo><mi>a</mi><msup><mi>x</mi><mn>2</mn></msup><mo>+</mo><mi>b</mi><mi>x</mi><mo>+</mo><mi>c</mi></mrow><annotation encoding="application/x-tex">f(x) = ax^2 +
+bx + c
+</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:1em;vertical-align:-0.25em;"></span><span class="mord mathnormal" style="margin-right:0.10764em;">f</span><span class="mopen">(</span><span class="mord mathnormal">x</span><span class="mclose">)</span><span class="mspace" style="margin-right:0.2778em;"></span><span class="mrel">=</span><span class="mspace" style="margin-right:0.2778em;"></span></span><span class="base"><span class="strut" style="height:0.9474em;vertical-align:-0.0833em;"></span><span class="mord mathnormal">a</span><span class="mord"><span class="mord mathnormal">x</span><span class="msupsub"><span class="vlist-t"><span class="vlist-r"><span class="vlist" style="height:0.8641em;"><span style="top:-3.113em;margin-right:0.05em;"><span class="pstrut" style="height:2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight">2</span></span></span></span></span></span></span></span><span class="mspace" style="margin-right:0.2222em;"></span><span class="mbin">+</span><span class="mspace" style="margin-right:0.2222em;"></span></span><span class="base"><span class="strut" style="height:0.7778em;vertical-align:-0.0833em;"></span><span class="mord mathnormal">b</span><span class="mord mathnormal">x</span><span class="mspace" style="margin-right:0.2222em;"></span><span class="mbin">+</span><span class="mspace" style="margin-right:0.2222em;"></span></span><span class="base"><span class="strut" style="height:0.4306em;"></span><span class="mord mathnormal">c</span></span></span></span></span></p>
+.
+
+Fence block over multiple lines
+.
+```math
+f(x) = ax^2 + bx + c \\
+y = mx + b
+```
+.
+<p class="katex-block"><span class="katex-display"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><semantics><mrow><mi>f</mi><mo stretchy="false">(</mo><mi>x</mi><mo stretchy="false">)</mo><mo>=</mo><mi>a</mi><msup><mi>x</mi><mn>2</mn></msup><mo>+</mo><mi>b</mi><mi>x</mi><mo>+</mo><mi>c</mi><mspace linebreak="newline"></mspace><mi>y</mi><mo>=</mo><mi>m</mi><mi>x</mi><mo>+</mo><mi>b</mi></mrow><annotation encoding="application/x-tex">f(x) = ax^2 + bx + c \\
+y = mx + b
+</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:1em;vertical-align:-0.25em;"></span><span class="mord mathnormal" style="margin-right:0.10764em;">f</span><span class="mopen">(</span><span class="mord mathnormal">x</span><span class="mclose">)</span><span class="mspace" style="margin-right:0.2778em;"></span><span class="mrel">=</span><span class="mspace" style="margin-right:0.2778em;"></span></span><span class="base"><span class="strut" style="height:0.9474em;vertical-align:-0.0833em;"></span><span class="mord mathnormal">a</span><span class="mord"><span class="mord mathnormal">x</span><span class="msupsub"><span class="vlist-t"><span class="vlist-r"><span class="vlist" style="height:0.8641em;"><span style="top:-3.113em;margin-right:0.05em;"><span class="pstrut" style="height:2.7em;"></span><span class="sizing reset-size6 size3 mtight"><span class="mord mtight">2</span></span></span></span></span></span></span></span><span class="mspace" style="margin-right:0.2222em;"></span><span class="mbin">+</span><span class="mspace" style="margin-right:0.2222em;"></span></span><span class="base"><span class="strut" style="height:0.7778em;vertical-align:-0.0833em;"></span><span class="mord mathnormal">b</span><span class="mord mathnormal">x</span><span class="mspace" style="margin-right:0.2222em;"></span><span class="mbin">+</span><span class="mspace" style="margin-right:0.2222em;"></span></span><span class="base"><span class="strut" style="height:0.4306em;"></span><span class="mord mathnormal">c</span></span><span class="mspace newline"></span><span class="base"><span class="strut" style="height:0.625em;vertical-align:-0.1944em;"></span><span class="mord mathnormal" style="margin-right:0.03588em;">y</span><span class="mspace" style="margin-right:0.2778em;"></span><span class="mrel">=</span><span class="mspace" style="margin-right:0.2778em;"></span></span><span class="base"><span class="strut" style="height:0.6667em;vertical-align:-0.0833em;"></span><span class="mord mathnormal">m</span><span class="mord mathnormal">x</span><span class="mspace" style="margin-right:0.2222em;"></span><span class="mbin">+</span><span class="mspace" style="margin-right:0.2222em;"></span></span><span class="base"><span class="strut" style="height:0.6944em;"></span><span class="mord mathnormal">b</span></span></span></span></span></p>
+.
+
+Should parse as code block (not math block)
+.
+start
+```
+f(x) = 2*x
+```
+end
+.
+<p>start</p>
+<pre><code>f(x) = 2*x
+</code></pre>
+<p>end</p>
+.
+
+

--- a/types.d.ts
+++ b/types.d.ts
@@ -17,6 +17,11 @@ export interface MarkdownKatexOptions {
     readonly enableMathInlineInHtml?: boolean;
 
     /**
+    Enable rendering of fenced math blocks.
+     */
+    readonly enableFencedBlocks?: boolean;
+
+    /**
      * Controls if an exception is thrown on katex errors.
      */
     readonly throwOnError?: boolean;


### PR DESCRIPTION
Adds support for rendering fenced math blocks
Continues PR #213750 from main vscode repo