### PR TITLE
Support inline math with optional backtick

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -513,7 +513,12 @@ export default function (md: import('markdown-it'), options?: MarkdownKatexOptio
     };
 
     const inlineRenderer = (tokens: readonly Token[], idx: number) => {
-        return katexInline(tokens[idx].content);
+        const content = tokens[idx].content;
+        // To support expression like $`1+1 = 2`$, check if the the expression has leading and trailing "`".
+        const hasBacktick = content.length > 2 && content[0] === "`" && content[content.length - 1] === "`";
+        const sanitized = hasBacktick ? content.slice(1, -1) : content;
+
+        return katexInline(sanitized);
     };
 
     const katexBlockRenderer = (latex: string) => {

--- a/test/fixtures/default.txt
+++ b/test/fixtures/default.txt
@@ -7,6 +7,13 @@ $1+1 = 2$
 <p><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding="application/x-tex">1+1 = 2</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.72777em;vertical-align:-0.08333em;"></span><span class="mord">1</span><span class="mspace" style="margin-right:0.2222222222222222em;"></span><span class="mbin">+</span><span class="mspace" style="margin-right:0.2222222222222222em;"></span></span><span class="base"><span class="strut" style="height:0.64444em;vertical-align:0em;"></span><span class="mord">1</span><span class="mspace" style="margin-right:0.2777777777777778em;"></span><span class="mrel">=</span><span class="mspace" style="margin-right:0.2777777777777778em;"></span></span><span class="base"><span class="strut" style="height:0.64444em;vertical-align:0em;"></span><span class="mord">2</span></span></span></span></p>
 .
 
+Simple inline math with backtick
+.
+$`1+1 = 2`$
+.
+<p><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mn>1</mn><mo>+</mo><mn>1</mn><mo>=</mo><mn>2</mn></mrow><annotation encoding="application/x-tex">1+1 = 2</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.72777em;vertical-align:-0.08333em;"></span><span class="mord">1</span><span class="mspace" style="margin-right:0.2222222222222222em;"></span><span class="mbin">+</span><span class="mspace" style="margin-right:0.2222222222222222em;"></span></span><span class="base"><span class="strut" style="height:0.64444em;vertical-align:0em;"></span><span class="mord">1</span><span class="mspace" style="margin-right:0.2777777777777778em;"></span><span class="mrel">=</span><span class="mspace" style="margin-right:0.2777777777777778em;"></span></span><span class="base"><span class="strut" style="height:0.64444em;vertical-align:0em;"></span><span class="mord">2</span></span></span></span></p>
+.
+
 Simple block math
 .
 $$1+1 = 2$$


### PR DESCRIPTION
This PR support inline math with optional backtick, allowing same style from GitHub/GitLab flavored markdown.

- #20
- microsoft/vscode#208430

There may be some better implementation, but it works. :D