### PR TITLE
feat: support custom katex instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,21 @@ $$\begin{array}{c}
 \end{array}$$
 ```
 
+### Katex extension
+```tsx
+import MarkdownIt from 'markdown-it'
+import katex from 'katex'
+import 'katex/contrib/mhchem'
+import 'katex/contrib/copy-tex'
+const md = new MarkdownIt()
+katexPlugin(md, {
+    katex,
+})
+
+const result = md.render('# Math Rulez! \n  $\\sqrt{3x-1}+(1+x)^2$');
+const chemResult = md.render('$\\ce{Hg^2+ ->[I-] HgI2 ->[I-] [Hg^{II}I4]^2-}$')
+```
+
 ## Syntax
 
 Math parsing in markdown is designed to agree with the conventions set by pandoc:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import katex from 'katex';
+import localKatex from 'katex';
 import type * as StateBlock from 'markdown-it/lib/rules_block/state_block';
 import type StateCore from 'markdown-it/lib/rules_core/state_core';
 import type * as StateInline from 'markdown-it/lib/rules_inline/state_inline';
@@ -459,6 +459,7 @@ function escapeHtml(unsafe: string): string {
 
 
 export default function (md: import('markdown-it'), options?: MarkdownKatexOptions) {
+    const katex = options?.katex ?? localKatex;
     const enableBareBlocks = options?.enableBareBlocks;
     const enableMathBlockInHtml = options?.enableMathBlockInHtml;
     const enableMathInlineInHtml = options?.enableMathInlineInHtml;

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,4 +1,5 @@
 import type MarkdownIt from 'markdown-it';
+import Katex from "katex"
 
 export interface MarkdownKatexOptions {
     /**
@@ -31,6 +32,11 @@ export interface MarkdownKatexOptions {
      * Controls if an exception is thrown on katex errors.
      */
     readonly throwOnError?: boolean;
+
+    /**
+     * Support for custom katex instance for extension such as mhchem 
+     */
+    katex?: typeof Katex
 }
 
 export default function (md: MarkdownIt, options?: MarkdownKatexOptions): MarkdownIt;


### PR DESCRIPTION
There is no way to support katex extension, e.g. https://github.com/KaTeX/KaTeX/tree/main/contrib/mhchem
One fork implement mech so we can support https://github.com/iktakahiro/markdown-it-katex/commit/5875bbb7bfa22e76dd433dfdd6e7c7e012dcbd80

Before:
![image](https://github.com/user-attachments/assets/c57a969a-a2c7-4e47-800a-e1ad4e079a46)

After:
![image](https://github.com/user-attachments/assets/0595eaf8-7201-4771-96f5-5a143373c26f)

It will be great if any better approach